### PR TITLE
Verify user permissions in load generation script

### DIFF
--- a/tests/loadgen/datagen.go
+++ b/tests/loadgen/datagen.go
@@ -76,6 +76,11 @@ func (d DataGen) GetProjects(username string) []ProjectImage {
     return d.UserProjectMapping[username]
 }
 
+// GetImageVersion returns a combination of a dummy docker image name and tag 
+func (d DataGen) GetImageVersion() ImageVersion {
+    return generateImageVersion()
+}
+
 func (d DataGen) addProject2User(username string, project ProjectImage) {
     projects, _ := d.UserProjectMapping[username]
     projects = append(projects, project)

--- a/tests/loadgen/domainobject.go
+++ b/tests/loadgen/domainobject.go
@@ -41,3 +41,12 @@ type ProjectReq struct {
 	// The public status of the project.
 	Public int32 `json:"public,omitempty"`
 }
+
+type MemberReq struct {
+
+	// The username of the user to be added as member
+	Username string `json:"username"`
+
+	// The role ids of the roles to be given to the member
+	Roles    []int  `json:"roles"`
+}


### PR DESCRIPTION
This patch checks for the permissions of a user to push images to a
repository.
It checks by making an unsuccessful push to the repository post which
the user is granted the appropriate membership which is followed by a
successful push.